### PR TITLE
Fix SQL injection in POST /api/notes endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -141,8 +141,7 @@ app.post('/api/notes', (req, res) => {
         
         saveDatabase();
         
-        const result = db.exec(`SELECT * FROM notes WHERE id = '${noteId}'`);
-        const notes = resultToObjects(result[0]);
+        const notes = queryAll('SELECT * FROM notes WHERE id = ?', [noteId]);
         res.status(201).json(notes[0]);
     } catch (error) {
         console.error('Error creating note:', error);
@@ -237,18 +236,6 @@ app.get('/api/health', (req, res) => {
 app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
-
-// Helper: Convert sql.js result to array of objects
-function resultToObjects(result) {
-    const { columns, values } = result;
-    return values.map(row => {
-        const obj = {};
-        columns.forEach((col, i) => {
-            obj[col] = row[i];
-        });
-        return obj;
-    });
-}
 
 // Start server
 initDatabase().then(() => {


### PR DESCRIPTION
## Summary

Fixes the SQL injection vulnerability in `POST /api/notes` by replacing the raw `db.exec()` string interpolation with the existing `queryAll()` helper that uses prepared statements.

## Changes

- **server.js**: Replaced `db.exec(\`SELECT * FROM notes WHERE id = '${noteId}'\`)` with `queryAll('SELECT * FROM notes WHERE id = ?', [noteId])`
- **server.js**: Removed the now-unused `resultToObjects()` helper function (was only used by the vulnerable code path)

## Testing

- Server starts without errors ✅
- POST /api/notes creates and returns notes correctly ✅
- Consistent with parameterized query pattern used in all other endpoints ✅

Refs #1