### PR TITLE
Add GitHub Actions CI for server health check on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  health-check:
+    name: Server Health Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check
+        run: node --check server.js
+
+      - name: Start server and verify health endpoint
+        run: |
+          # Start server in background with a fresh data dir
+          DATA_DIR=/tmp/ci-test-data node server.js &
+          SERVER_PID=$!
+
+          # Wait for server to be ready (up to 15s)
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+              echo "✅ Server is up"
+              break
+            fi
+            echo "Waiting for server... ($i/15)"
+            sleep 1
+          done
+
+          # Hit the health endpoint and assert response
+          RESPONSE=$(curl -sf http://localhost:3000/api/health)
+          echo "Health response: $RESPONSE"
+
+          echo "$RESPONSE" | grep -q '"status":"ok"' || {
+            echo "❌ Health check failed: expected status=ok"
+            kill $SERVER_PID 2>/dev/null
+            exit 1
+          }
+
+          echo "✅ Health check passed"
+          kill $SERVER_PID 2>/dev/null
+
+      - name: Run tests (if available)
+        run: |
+          if [ -f "test/api.test.js" ]; then
+            echo "Running API test suite..."
+            npm test
+          else
+            echo "No test suite found — skipping (see issue #7)"
+          fi


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow so every push and PR gets automated validation.

## What It Does

`.github/workflows/ci.yml` runs on every push and every PR:

1. **Syntax check** — `node --check server.js` (fast, no server start needed)
2. **Boot + health check** — starts the server against an isolated `/tmp` data dir, waits up to 15s, then hits `GET /api/health` and asserts `status: ok`
3. **Test suite** — runs `npm test` if `test/api.test.js` is present (gracefully skipped until PR #8 is merged)

## Why It Matters

Right now there are 4 open PRs (#4, #6, #8, #9) touching `server.js` with no automated gate. This workflow gives quick confidence that any change doesn't break the server before Hayden reviews/merges.

## Testing Done

Verified locally on master:
- `node --check server.js` → Syntax OK
- Server starts, `/api/health` returns `{"status":"ok"}`, process exits cleanly

Refs #10