### PR TITLE
feat: add full-text search to GET /api/notes

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,10 +82,10 @@ function queryAll(sql, params = []) {
 
 // API Routes
 
-// Get all notes (with optional date filter)
+// Get all notes (with optional date, type, and full-text search filters)
 app.get('/api/notes', (req, res) => {
     try {
-        const { date, type } = req.query;
+        const { date, type, q } = req.query;
         let query = 'SELECT * FROM notes';
         const conditions = [];
         const params = [];
@@ -97,6 +97,12 @@ app.get('/api/notes', (req, res) => {
         if (type) {
             conditions.push('type = ?');
             params.push(type);
+        }
+        if (q && q.trim()) {
+            // Case-insensitive search across title, content, and transcription
+            const pattern = `%${q.trim()}%`;
+            conditions.push('(title LIKE ? OR content LIKE ? OR transcription LIKE ?)');
+            params.push(pattern, pattern, pattern);
         }
         
         if (conditions.length > 0) {


### PR DESCRIPTION
## Summary

Adds a `?q=` query parameter to `GET /api/notes` enabling keyword search across all text fields.

## Problem

The app had no way to search notes by content. With only `date` and `type` filters, finding a specific memo in a large collection was impossible.

## Solution

Extend the existing filter logic with a `q` parameter that runs a case-insensitive `LIKE` search across `title`, `content`, and `transcription`.

## Changes

**server.js** (+8 lines, -2 lines)
- Destructure `q` from `req.query` in the GET /api/notes handler
- If `q` is provided and non-empty, add a `WHERE` condition matching any of the three text fields using parameterized `LIKE`
- All existing `date` and `type` filters compose correctly with `q`

## Examples

```bash
# Search all note types
GET /api/notes?q=meeting

# Combine with type filter
GET /api/notes?q=grocery&type=voice

# Combine with date filter
GET /api/notes?q=project&date=2026-02-18
```

## Testing

Manually tested:
- ✅ `?q=meeting` returns note with "Meeting" in title
- ✅ `?q=milk` returns voice note with "milk" in transcription
- ✅ `?q=` (empty) returns all notes — no regression
- ✅ No `q` returns all notes — no regression
- ✅ Server starts with no errors, passes syntax check
- ✅ Uses parameterized SQL (no injection risk)

Refs #12